### PR TITLE
Ensure date resets after every submission

### DIFF
--- a/index.html
+++ b/index.html
@@ -558,7 +558,6 @@
         
         if (response.status === 200) {
           alert('Timesheet submitted successfully!');
-          document.getElementById('timesheet-form').reset();
         } else {
           throw new Error('Email service returned non-200 status');
         }
@@ -566,6 +565,14 @@
         console.error('Submission error:', error);
         alert('Failed to submit timesheet. Please try again or contact support if the problem persists.');
       } finally {
+        const form = document.getElementById('timesheet-form');
+        form.reset();
+
+        // Reapply today's date after form reset
+        const today = new Date();
+        const dateStr = today.toLocaleDateString('en-CA');
+        document.getElementById('date').value = dateStr;
+
         submitBtn.disabled = false;
         submitBtn.textContent = originalBtnText;
       }


### PR DESCRIPTION
## Summary
- keep today's date set after `reset()` is called
- reapply the date whether the submission succeeds or fails

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_b_68732904c9ac832dbb04017160ea8bb7